### PR TITLE
ci: bump GitHub Actions to Node 24 majors

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.x'
 
@@ -42,7 +42,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
         fetch-tags: true
@@ -106,14 +106,14 @@ jobs:
 
     steps:
     - name: Checkout tag
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         ref: ${{ needs.tag.outputs.tag }}
         fetch-depth: 0
         fetch-tags: true
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.x'
 
@@ -132,7 +132,7 @@ jobs:
           || { echo "Built artifacts do not match expected version ${{ needs.tag.outputs.version }}"; exit 1; }
 
     - name: Upload package artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: python-package
         path: dist/
@@ -151,7 +151,7 @@ jobs:
 
     steps:
     - name: Download package artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         name: python-package
         path: dist/


### PR DESCRIPTION
## Summary
Updates the Node-based GitHub Actions in the PyPI publish workflow to versions that run on Node.js 24, silencing the Node.js 20 deprecation warning:

- `actions/checkout@v4` → `@v5`
- `actions/setup-python@v5` → `@v6`
- `actions/upload-artifact@v4` → `@v5`
- `actions/download-artifact@v4` → `@v5`

`pypa/gh-action-pypi-publish@release/v1` is unaffected (runs in a Docker container).

## Note
No `major`/`minor` label, so merging this triggers a **patch** release (→ `v2.1.5`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)